### PR TITLE
Makes comments serializable

### DIFF
--- a/src/COMMENT.ts
+++ b/src/COMMENT.ts
@@ -1,16 +1,14 @@
 /* eslint-disable no-underscore-dangle */
-const $comment = Symbol('ArchieML comment value');
-
 export interface Comment {
-  __symbol: typeof $comment;
+  __$archieML_comment: true;
   value: string;
 }
 
 export const COMMENT = (value: string): Comment => ({
-  __symbol: $comment,
+  __$archieML_comment: true,
   value,
 });
 
 export function isComment(value: unknown): value is Comment {
-  return typeof value === 'object' && (value as Comment).__symbol === $comment;
+  return typeof value === 'object' && (value as Comment).__$archieML_comment;
 }


### PR DESCRIPTION
For ArchieML comments created with the `COMMENT()` util, replace the symbol indicating a comment with a regular field.

This fixes a bug where if an object meant to be stringified as ArchieML is first serialized as JSON, comments will turn into scoped objects because Symbols cannot be serialized as JSON. Then, archieml-stringify will not recognize that value as a comment and instead add an undesired scope to the ArchieML output .